### PR TITLE
swap in byebyte for filedestroyer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "filedestroyer",
+  "name": "byebyte",
   "version": "0.0.0",
   "description": "",
   "main": "index.js",
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "bin": {
-    "filedestroyer": "index.js"
+    "byebyte": "index.js"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
![](https://cloud.githubusercontent.com/assets/1306968/9420601/088fcb36-482d-11e5-88c4-04034b9f0bce.gif)

This renames the package to byebyte so that it can be run as

```
byebyte -f in.gif -o out.gif
```

after an `npm i -g`.

If byebyte is published to npm, folks will be able to run `npm i -g byebyte` to have access to the script without cloning.
